### PR TITLE
fix: "doc" gulp task will no longer use global binary

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,7 +217,7 @@ gulp.task('gen-doc-travis',function(){
  */
 
 gulp.task('doc', function(cb) {
-  child_process.exec("typedoc --out ./ci/docs" + branch + " --module commonjs --target es5 --name jThree ./jThree/src/", cb);
+  child_process.exec("./node_modules/.bin/typedoc --out ./ci/docs" + branch + " --module commonjs --target es5 --name jThree ./jThree/src/", cb);
   return void 0;
 });
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "shader-loader": "^1.1.2",
     "ts-loader": "^0.4.3",
     "tsdoc": "0.0.4",
+    "typedoc": "^0.3.4",
     "typescript": "^1.4.1",
     "webpack": "^1.8.9",
     "yargs": "^3.8.0"


### PR DESCRIPTION
gulp docを実行したところ、globalのtypedocを参照していたためビルドに失敗したので、node_modules内のバイナリを使うように修正しました。