### PR TITLE
Fix/dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 - echo "                                                                                                                                     " >> .travis.sh
 - echo "                                                                                                                                     " >> .travis.sh
 - cat .travis.sh
-- npm install -global npm
 - rm ci -r -f
 - mkdir ci
 - cd ci
@@ -38,6 +37,7 @@ before_install:
 - ls
 - cd ..
 - ls
+- npm -v
 install:
 - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ before_install:
 - echo "                                                                                                                                     " >> .travis.sh
 - cat .travis.sh
 - npm install -global npm
-- npm install tsd -global
-- npm install gulp -global
-- npm install typedoc -global
 - rm ci -r -f
 - mkdir ci
 - cd ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_install:
 - ls
 - cd ..
 - ls
-- npm -v
 install:
 - npm install
 script:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This library depend on these below library, we appriciate these all of the contr
 
 |Name|Purpose|URL|Memo|
 |:-:|:-:|:-:|:-:|
-|jQuery|Use for search goml tag.|https://jquery.com/| **This dependency will be removed soon** |
 |superagent|Use for ajax to resolve plugins|https://visionmedia.github.io/superagent/||
 |gl-matrix|Use for calculation for webgl|https://github.com/toji/gl-matrix||
 

--- a/jThree/src/Base/Collections/Collection.ts
+++ b/jThree/src/Base/Collections/Collection.ts
@@ -1,6 +1,6 @@
 ﻿import IEnumrator = require("./IEnumrator");
 import IEnumerable = require("./IEnumerable");
-import Delegates=require("Delegates");
+import Delegates=require("../Delegates");
 
 /**
  * Containing some of methods use for IEnumerable generic interfaces.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sinon-chai": "^2.8.0",
     "source-map-support": "^0.3.2",
     "ts-loader": "^0.5.0",
-    "tsify": "^0.11.10",
+    "tsify": "^0.12.2",
     "typedoc": "^0.3.8",
     "typescript": "^1.5.3",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
fix npm peerDependencies problem (causing travis check failure)

Now travis error is not caused by dependencies problem.

resolve #97