### PR TITLE
Fix TravisCI test falling

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "es6",
     "noImplicitAny": false,
-    "sourceMap": true
+    "sourceMap": true,
+    "module": "commonjs"
   },
   "filesGlob": [
     "./refs/**/*.ts",


### PR DESCRIPTION
コンパイル時、`module.exports.esModule`を`true`にする設定です。
これにより、babelで`import`が正常に行えます。

この問題は[babel-plugin-add-module-exports](https://github.com/59naga/babel-plugin-add-module-exports#why)でも取り上げています、よろしければ参考にしてください。