### PR TITLE
Fixed build error

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -43,7 +43,7 @@ config =
       sourcemap: !args.nosourcemap
       transform: [
         {name:'txtify', opt: {extensions: ['.json','.html','.css','.glsl','.xmml','.rsml','.xml']}}
-        {name: 'babelify'}
+        {name: 'babelify', opt:{presets: ["es2015"]}}
         {name: 'envify', opt: {NODE_ENV: (if env_production then 'production' else 'development')}}
       ]
       detectGlobals: true


### PR DESCRIPTION
Babelify needs "presets" option , or build error
"'import' and 'export' may appear only with 'sourceType: module'".
This came from Babel's incompatible update.

see https://github.com/babel/babelify#options
http://qiita.com/do7be/items/521dd4e61a237e885818 .